### PR TITLE
Fixed minor edits

### DIFF
--- a/sections/git.md
+++ b/sections/git.md
@@ -39,7 +39,7 @@ https://git-scm.com/download/win
 
 ![textbox with browse button listing start menu folder options](../images/windows/git/git04.png)
 
-6. Choose the default editor used by Git. Select `Visual Studio Code` as the default editor. *Click* `Next`:
+6. Choose the default editor used by Git. Select `Visual Studio Code` as the default editor. (Note that you must [install `Visual Studio Code`](vscode.md) first before you can move forward past this step of the Git install.) *Click* `Next`:
 
 ![installation menu containing drop down of editor options: nano, vim, notepad++, visual studio code, visual studio code insiders](../images/windows/git/git06.png)
 
@@ -64,7 +64,7 @@ Note: Do not choose "Use MinTTY (the default terminal of MSYS2)" as that MinTTY 
 
 ![check boxes: 1) enable file system caching, 2) enable git credential manager, 3) enable symbolic links](../images/windows/git/git11.png)
 
-13. VSCode should now be installing:
+13. Git should now be installing:
  
  ![image of progress bar](../images/windows/git/git12.png)
 


### PR DESCRIPTION
Fixed "vs code" to "git should now be installing". Added note that you must install vs code first in order to install git with it configured with vs code as the default editor. I just tried this on a friend's PC and you can't move forward and click "next" on the Git install otherwise.