### PR TITLE
Fixed Digital Ethics Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Session | Software Installation Instructions
 [Mapping](https://github.com/DHRI-Curriculum/mapping) | [QGIS](sections/qgis.md) |
 [Machine Learning](https://github.com/DHRI-Curriculum/machine-learning)| [Python](sections/python.md), [Pandas](sections/pandas.md), [NLTK](sections/nltk.md), [Sklearn](sections/sklearn.md)|
 [HTML/CSS](https://github.com/DHRI-Curriculum/html-css) | [VScode](sections/vscode.md), [Firefox](https://www.mozilla.org/en-US/firefox/new/) |
-[Digital Ethics](https://github.com/DHRI-Curriculum/digital-ethics) |
+[Digital Ethics](https://github.com/DHRI-Curriculum/ethics) |
 [Omeka](https://github.com/GCDigitalFellows/omeka/) | [Omeka](https://github.com/GCDigitalFellows/omeka/blob/master/omekainstall.md) |
 <!-- [Twitter API](https://github.com/DHRI-Curriculum/twitter-api) | [Python](sections/python.md), [Tweepy](sections/tweepy.md) |-->
 


### PR DESCRIPTION
the link that's currently on the readme yields a 404 error, so I changed it to the ethics repo I found in the DHRI repo. cc @kchatlosh if there's a different one to use.