### PR TITLE
fix broken link

### DIFF
--- a/sections/git.md
+++ b/sections/git.md
@@ -5,7 +5,7 @@ Git is a distributed version control system used to manage changes to text files
 
 On OS/X, git is part of the xcode command line tools. To install them:
 
-1. Open a [terminal](osx_terminal).
+1. Open a [terminal](osx_terminal.md).
 
 2. Type the following in the terminal:
 ```bash


### PR DESCRIPTION
The link was producing a 404 Not Found error because it was missing the `.md` extension.